### PR TITLE
Fix display of languages

### DIFF
--- a/src/fetch_info.py
+++ b/src/fetch_info.py
@@ -44,7 +44,7 @@ def format_languages(languages: dict) -> str:
     max_languages = config.get("max_languages", -1)
     if max_languages != -1:
         sorted_lang = sorted_lang[:max_languages]
-    return '\n'.join([f"- {lang}: {bytes_count} bytes of code" for lang, bytes_count in sorted_lang]) # The GitHUB API returns the bytes of code written in a language, not the lines of code
+    return '\n' + '\n'.join([f"- {lang}: {bytes_count} bytes of code" for lang, bytes_count in sorted_lang]) # The GitHUB API returns the bytes of code written in a language, not the lines of code
 
 def fetch_stats(g: Github) -> dict:
     user = g.get_user()

--- a/src/gen_readme.py
+++ b/src/gen_readme.py
@@ -134,7 +134,7 @@ def gen_image(g: Github):
                             y_offset += line_spacing
                 if line:
                     draw.text((x_current, y_offset), ' '.join(line), fill=text_color, font=font)
-                    y_offset += line_spacing
+                y_offset += line_spacing
             else:
                 words = info_line.split()
                 line = []
@@ -159,7 +159,7 @@ def gen_image(g: Github):
                 
                 if line:
                     draw.text((x_current, y_offset), ' '.join(line), fill=text_color, font=font)
-                    y_offset += line_spacing
+                y_offset += line_spacing
 
     # Check if the text goes out of bounds and adjust the image height if necessary
     if y_offset > initial_height:


### PR DESCRIPTION
Currently the first language in the list is displayed inline with the row header, with the subsequent languages in the list displayed on the following lines, one line per language.

This change moves the first language in the list to its own line to be uniform with the other languages. Subsequently this also fixes the color formatting which was missing from the first language in the list.

Before:
![before](https://github.com/user-attachments/assets/92addcfd-b4e2-4dcf-8ccb-4be7f277514c)

After:
![after](https://github.com/user-attachments/assets/65bacd01-8595-4227-a628-b8ad82aab156)
